### PR TITLE
Make sorting deterministic across different types and always put null/undefined at the bottom of both ascending/descending

### DIFF
--- a/index.js
+++ b/index.js
@@ -201,7 +201,18 @@ Query.ascending = function $property(ref) {
       d.sortkey = keys[i];
     });
     obj = obj.sort(function(a,b) {
-      return a.sortkey - b.sortkey;
+      let aNull = (a === null || a === undefined);
+      let bNull = (b === null || b === undefined);
+      if (aNull || bNull) {
+        return (aNull && !bNull) ? -1 : (bNull && !aNull) ? 1 : 0;
+      }
+      let aVal = Number(a.sortkey) || a.sortkey;
+      let bVal = Number(b.sortkey) || b.sortkey;
+      if (typeof aVal !== typeof bVal) {
+        aVal = typeof aVal;
+        bVal = typeof bVal;
+      }
+      return aVal < bVal ? -1 : aVal > bVal ? 1 : 0;
     });
     return setPrototype(self)(obj);
   }];
@@ -210,6 +221,17 @@ Query.ascending = function $property(ref) {
 Query.descending = function $property(ref) {
   var self = this;
   return [{q:this},'q.ascending.'+ref,function(ascending) {
+    let undefinedValues = [];
+    for (var i = ascending.length - 1; i >= 0; i--) {
+      if (ascending[i].sortkey !== null && ascending[i].sortkey !== undefined) {
+        break;
+      }
+      undefinedValues.push(ascending[i]);
+    }
+    if (undefinedValues.length) {
+      ascending = undefinedValues.concat(ascending.slice(0, ascending.length - undefinedValues.length));
+    }
+
     return setPrototype(self)(ascending.slice().reverse());
   }];
 };

--- a/index.js
+++ b/index.js
@@ -206,8 +206,10 @@ Query.ascending = function $property(ref) {
       if (aNull || bNull) {
         return (aNull && !bNull) ? -1 : (bNull && !aNull) ? 1 : 0;
       }
-      let aVal = Number(a.sortkey) || a.sortkey;
-      let bVal = Number(b.sortkey) || b.sortkey;
+      let aVal = Number(a.sortkey);
+      if (isNaN(aVal)) aVal = a.sortkey;
+      let bVal = Number(b.sortkey);
+      if (isNaN(bVal)) bVal = b.sortkey;
       if (typeof aVal !== typeof bVal) {
         aVal = typeof aVal;
         bVal = typeof bVal;

--- a/test/asc-desc-test.js
+++ b/test/asc-desc-test.js
@@ -4,20 +4,19 @@ var clues = require('clues'),
     data = require('./data');
 
 data = Object.create(data);
+data.push({'Country': 'France', 'Aspect': 'French_Fries', 'Value': undefined});
 
 describe('ascending',function() {
   it('returns a sorted array',function() {
     return clues(data,'ascending.Value')
       .then(function(d) {
         assert(Query.isPrototypeOf(d),'result does not have a Query prototype');
-        assert.equal(d.length,31);
+        assert.equal(d.length,32);
 
-        var last = -Infinity;
-        d.forEach(function(d) {
-          if (isNaN(d.Value)) return;
-          assert(last <= d.Value,'Previous value should be less');
-          last = d.Value;
-        });
+        let expectedList = [41, 55, 56, 69, 71, 72, 76, 77, 78, 79, 81, 81, 81, 82, 82, 86, 87, 87, 87, 92, 92, 95, 96, 100, 100, 100, 100, 100, 100, 100, 'NOT NUMBER', undefined];
+        for (let i = 0; i < expectedList.length; i++) {
+          assert(d[i].Value === expectedList[i], `Values should match: ${d[i].Value} and ${expectedList[i]}`);
+        }
       });
   });
 });
@@ -27,14 +26,31 @@ describe('descending',function() {
     return clues(data,'descending.Value')
       .then(function(d) {
         assert(Query.isPrototypeOf(d),'result does not have a Query prototype');
-        assert.equal(d.length,31);
+        assert.equal(d.length,32);
 
-        var last = Infinity;
-        d.forEach(function(d) {
-          if (isNaN(d.Value)) return;
-          assert(last >= d.Value,'Previous value should be higher');
-          last = d.Value;
-        });
+
+        let expectedList = ['NOT NUMBER', 100, 100, 100, 100, 100, 100, 100, 96, 95, 92, 92, 87, 87, 87, 86, 82, 82, 81, 81, 81, 79, 78, 77, 76, 72, 71, 69, 56, 55, 41, undefined];
+        for (let i = 0; i < expectedList.length; i++) {
+          assert(d[i].Value === expectedList[i], `Values should match: ${d[i].Value} and ${expectedList[i]}`);
+        }
+      });
+  });
+
+  it('doesnt break if all undefined', function() {
+    data = Object.setPrototypeOf([
+      {'Country': 'France', 'Aspect': 'French_Fries', 'Value': undefined},
+      {'Country': 'Spain', 'Aspect': 'Spench_Fries', 'Value': undefined},
+      {'Country': 'England', 'Aspect': 'English_Fries', 'Value': null}], Query);
+    return clues(data,'descending.Value')
+      .then(function(d) {
+        assert(Query.isPrototypeOf(d),'result does not have a Query prototype');
+        assert.equal(d.length,3);
+
+
+        let expectedList = [null, undefined, undefined];
+        for (let i = 0; i < expectedList.length; i++) {
+          assert(d[i].Value === expectedList[i], `Values should match: ${d[i].Value} and ${expectedList[i]}`);
+        }
       });
   });
 });

--- a/test/asc-desc-test.js
+++ b/test/asc-desc-test.js
@@ -5,6 +5,7 @@ var clues = require('clues'),
 
 data = Object.create(data);
 data.push({'Country': 'France', 'Aspect': 'French_Fries', 'Value': undefined});
+data[2] = Object.create(data[2], { Value: { value: '0' } });
 
 describe('ascending',function() {
   it('returns a sorted array',function() {
@@ -13,7 +14,7 @@ describe('ascending',function() {
         assert(Query.isPrototypeOf(d),'result does not have a Query prototype');
         assert.equal(d.length,32);
 
-        let expectedList = [41, 55, 56, 69, 71, 72, 76, 77, 78, 79, 81, 81, 81, 82, 82, 86, 87, 87, 87, 92, 92, 95, 96, 100, 100, 100, 100, 100, 100, 100, 'NOT NUMBER', undefined];
+        let expectedList = ['0', 41, 55, 56, 69, 71, 72, 76, 77, 78, 79, 81, 81, 82, 82, 86, 87, 87, 87, 92, 92, 95, 96, 100, 100, 100, 100, 100, 100, 100, 'NOT NUMBER', undefined];
         for (let i = 0; i < expectedList.length; i++) {
           assert(d[i].Value === expectedList[i], `Values should match: ${d[i].Value} and ${expectedList[i]}`);
         }
@@ -29,7 +30,7 @@ describe('descending',function() {
         assert.equal(d.length,32);
 
 
-        let expectedList = ['NOT NUMBER', 100, 100, 100, 100, 100, 100, 100, 96, 95, 92, 92, 87, 87, 87, 86, 82, 82, 81, 81, 81, 79, 78, 77, 76, 72, 71, 69, 56, 55, 41, undefined];
+        let expectedList = ['NOT NUMBER', 100, 100, 100, 100, 100, 100, 100, 96, 95, 92, 92, 87, 87, 87, 86, 82, 82, 81, 81, 79, 78, 77, 76, 72, 71, 69, 56, 55, 41, '0', undefined];
         for (let i = 0; i < expectedList.length; i++) {
           assert(d[i].Value === expectedList[i], `Values should match: ${d[i].Value} and ${expectedList[i]}`);
         }


### PR DESCRIPTION
clues-query was assuming that the values sorted by were ALWAYS numbers and always had a value.  This is not necessarily the case.  