### PR TITLE
add flat support

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,3 +169,8 @@ Will make sure the results of `cq` is a clues-query array.  Will operate only on
 
 Equivalent to `.select.[xxxx].0`.  Any arrays returned will be `clues-query` arrays.
 
+
+### `.flat`
+
+Solves all keys (via `expand`) and flattens all values into a single 1-dimensional array
+

--- a/index.js
+++ b/index.js
@@ -284,9 +284,7 @@ Query.distinct = function($valueFn, $global) {
 };
 
 Query.expand = function($global) {
-  console.log('doing expand');
   return Promise.map(this,function(d) {
-    console.log('in promise map', d);
     if (typeof d !== 'object' || !d) {
       return d;
     }
@@ -299,9 +297,7 @@ Query.expand = function($global) {
   .then(setPrototype(this));
 };
 
-Query.flat = function(__expand) {
-  console.log(__expand);
-  var expand = __expand;
+Query.flat = function(expand) {
   var args = [];
   expand.forEach(item => {
     if (item === null || item === undefined) {

--- a/index.js
+++ b/index.js
@@ -284,14 +284,37 @@ Query.distinct = function($valueFn, $global) {
 };
 
 Query.expand = function($global) {
+  console.log('doing expand');
   return Promise.map(this,function(d) {
+    console.log('in promise map', d);
+    if (typeof d !== 'object' || !d) {
+      return d;
+    }
     for (var key in d) {
-      if (d[key] && (typeof d[key] === 'function' || (d[key].length && typeof d[key][d[key].length-1] === 'function') || d[key].then))
-        d[key] = clues(d,key,$global);
+      if ((d[key] !== null && d[key] !== undefined) && (typeof d[key] === 'function' || (d[key].length && typeof d[key][d[key].length-1] === 'function') || d[key].then))
+        d[key] = clues(d,key,$global).catch(noop);
     }
     return Promise.props(d);
   })
   .then(setPrototype(this));
+};
+
+Query.flat = function(__expand) {
+  console.log(__expand);
+  var expand = __expand;
+  var args = [];
+  expand.forEach(item => {
+    if (item === null || item === undefined) {
+      return;
+    }
+    if (typeof item === 'object') {
+      args = args.concat(Object.values(item).filter(a => a !== null && a !== undefined));
+    }
+    else {
+      args.push(item);
+    }
+  });
+  return setPrototype(this)([].concat.apply([], args));
 };
 
 Query.reversed = function() {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "moment": "^2.14.0"
   },
   "devDependencies": {
-    "tap": "^11.1.5",
+    "tap": "^14.10.8",
     "pegjs": "^0.10.0"
   },
   "jshintConfig": {

--- a/test/expand-test.js
+++ b/test/expand-test.js
@@ -3,8 +3,9 @@ var clues = require('clues'),
     
     data = require('./data');
 
+var data2 = Object.create(data);
+data2.push(5);
 data = Object.create(data);
-
 
 // Create nested promises for flattening
 data.forEach(function(d,i) {
@@ -35,6 +36,36 @@ t.test('expand',{autoend:true},function(t) {
           if (d.Aspect !== 'Undefined')
             t.same(typeof d.Value,'number');
         });
+      });
+  });
+
+  t.test('doesnt break on non-objects',{autoend:true},function(t) {
+    return clues(data2,'expand')
+      .then(function(d) {
+        t.ok(Query.isPrototypeOf(d),'result does not have a Query prototype');
+        t.same(d.length,32);
+        d.forEach(function(d,i) {
+          if (i === 31) {
+            t.same(d, 5);
+            return;
+          }
+          t.same(typeof d.Country,'string');
+          t.same(typeof d.Aspect,'string');
+          if (d.Aspect !== 'Undefined')
+            t.same(typeof d.Value,'number');
+        });
+      });
+  });
+
+  t.test('doesnt break on non-objects',{autoend:true},function(t) {
+    var data3 = Object.setPrototypeOf([{a:2},6,{d:Promise.resolve(6)}], Query);
+    return clues(data3,'expand')
+      .then(function(d) {
+        t.ok(Query.isPrototypeOf(d),'result does not have a Query prototype');
+        t.same(d.length,3);
+        t.same(d[1],6);
+        t.same(d[0].a,2);
+        t.same(d[2].d,6);
       });
   });
 });

--- a/test/flat-test.js
+++ b/test/flat-test.js
@@ -1,0 +1,28 @@
+var clues = require('clues'),
+    Query = require('../index'),
+    Promise = clues.Promise;
+
+const data = Object.setPrototypeOf([
+  { a:5, b: [2,3] },
+  6,
+  Promise.resolve([5,6]),
+  { c: null, b: ()=> Promise.reject('foop'), a: Promise.reject('wtf'), d: Promise.resolve(undefined), e: Promise.resolve(8) },
+  null,
+  "some string",
+  undefined,
+  false,
+  0
+], Query);
+
+module.exports = t => {
+
+t.test('flat test',{autoend:true},function(t) {
+  return clues(data,'flat')
+    .then(function(d) {
+      t.same(d, [ 5, 2, 3, 6, 5, 6, 8, 'some string', false, 0 ], 'confirm matches');
+    });
+});
+          
+};
+
+if (!module.parent) module.exports(require('tap'));


### PR DESCRIPTION
Closes #22 

Make `expand` safer and more robust, also add `flat` support, which uses `expand`