### PR TITLE
Split

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,8 +176,8 @@ Returns a object that provides d3-like scale functions for a given variable for 
 Returns a string concatenation of all values, either separated by ampersand (`.join`) or with no separator (`.connect`).  As this is a string concatination you probably need to select the string properties first, example: `distinct.Country.join`
 
 ### `.split(path,separator)`, `.split((path.to.something),separator)`
-If the path returns a string, splits the string into an array using the optional separator.  Comma is the default separator.  If the path contains multiple pieces, it must be enclosed in parentheses.  If the separator is not quoted,
-it will be evaluated, with the result becoming the separator.
+If the path returns a string, splits the string into an array using the optional separator.  Comma is the default separator.  If the path contains multiple pieces or pipes, it must be enclosed in parentheses.  If the separator 
+is not quoted, it will be evaluated, with the result becoming the separator.
 
 ### `.cq.(path.to.something.in.item)`
 

--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ Returns a object that provides d3-like scale functions for a given variable for 
 ### `.join` and `.connect`
 Returns a string concatenation of all values, either separated by ampersand (`.join`) or with no separator (`.connect`).  As this is a string concatination you probably need to select the string properties first, example: `distinct.Country.join`
 
-### `.split(path,separator)`, `.split((path.to.something),separator)`
+### `.split(path)`, `.split(path,separator)`, `.split((path.to.something),separator)`
 If the path returns a string, splits the string into an array using the optional separator.  Comma is the default separator.  If the path contains multiple pieces or pipes, it must be enclosed in parentheses.  If the separator 
 is not quoted, it will be evaluated, with the result becoming the separator.
 

--- a/README.md
+++ b/README.md
@@ -175,8 +175,9 @@ Returns a object that provides d3-like scale functions for a given variable for 
 ### `.join` and `.connect`
 Returns a string concatenation of all values, either separated by ampersand (`.join`) or with no separator (`.connect`).  As this is a string concatination you probably need to select the string properties first, example: `distinct.Country.join`
 
-### `.split(path.to.something,separator)`
-If the path returns a string, splits the string into an array using the optional separator.  Comma is the default separator.
+### `.split(path,separator)`, `.split((path.to.something),separator)`
+If the path returns a string, splits the string into an array using the optional separator.  Comma is the default separator.  If the path contains multiple pieces, it must be enclosed in parentheses.  If the separator is not quoted,
+it will be evaluated, with the result becoming the separator.
 
 ### `.cq.(path.to.something.in.item)`
 

--- a/README.md
+++ b/README.md
@@ -175,6 +175,9 @@ Returns a object that provides d3-like scale functions for a given variable for 
 ### `.join` and `.connect`
 Returns a string concatenation of all values, either separated by ampersand (`.join`) or with no separator (`.connect`).  As this is a string concatination you probably need to select the string properties first, example: `distinct.Country.join`
 
+### `.split(path.to.something,separator)`
+If the path returns a string, splits the string into an array using the optional separator.  Comma is the default separator.
+
 ### `.cq.(path.to.something.in.item)`
 
 Will make sure the results of `cq` is a clues-query array.  Will operate only on the first element of the array and solve into that item and wrap the result in an array if it isn't already an array

--- a/ast.js
+++ b/ast.js
@@ -82,7 +82,7 @@ function astToString(node, pretty=false, depth=0, ignoreFirstIndent=false) {
     result = `cq(${astToString(node.cq, pretty, depth+1, true)})`;
   }
   else if (typeof node === "object" && node.split) {
-    result = `split(${astToString(node.split, pretty, depth+1)}`;
+    result = `split(${astToString(node.split.thingToSplit, pretty, depth+1)}${node.split.splitBy ? ',' +astToString(node.split.splitBy, pretty, depth+1) : ''})`;
   }
   else if (node.equationPart) {
     result = astToString(node.equationPart, pretty, depth);

--- a/ast.js
+++ b/ast.js
@@ -81,6 +81,9 @@ function astToString(node, pretty=false, depth=0, ignoreFirstIndent=false) {
   else if (node.cq) {
     result = `cq(${astToString(node.cq, pretty, depth+1, true)})`;
   }
+  else if (typeof node === "object" && node.split) {
+    result = `split(${astToString(node.split, pretty, depth+1)}`;
+  }
   else if (node.equationPart) {
     result = astToString(node.equationPart, pretty, depth);
   }

--- a/build/pegjs-parser.js
+++ b/build/pegjs-parser.js
@@ -251,65 +251,72 @@ function peg$parse(input, options) {
           cq: path
         }
       },
-      peg$c69 = "if(",
-      peg$c70 = peg$literalExpectation("if(", false),
-      peg$c71 = function(condition, ifTrue, ifFalse) { return { 
+      peg$c69 = "split",
+      peg$c70 = peg$literalExpectation("split", false),
+      peg$c71 = function(operation, path) {
+        return {
+          split: path
+        }
+      },
+      peg$c72 = "if(",
+      peg$c73 = peg$literalExpectation("if(", false),
+      peg$c74 = function(condition, ifTrue, ifFalse) { return { 
           if: {
             condition, ifTrue, ifFalse
           } 
         }; 
       },
-      peg$c72 = function(equationPart) {
+      peg$c75 = function(equationPart) {
         return { equationPart }
       },
-      peg$c73 = function(head, tail) {
+      peg$c76 = function(head, tail) {
         return {
           piped: [head].concat(tail.map(e => e[1])).filter(a => a !== null)
         };
       },
-      peg$c74 = function(left, operation, right) {
+      peg$c77 = function(left, operation, right) {
         return {
           equation: { left, right },
           operation
         }
       },
-      peg$c75 = "=",
-      peg$c76 = peg$literalExpectation("=", false),
-      peg$c77 = "<=",
-      peg$c78 = peg$literalExpectation("<=", false),
-      peg$c79 = ">=",
-      peg$c80 = peg$literalExpectation(">=", false),
-      peg$c81 = "<",
-      peg$c82 = peg$literalExpectation("<", false),
-      peg$c83 = ">",
-      peg$c84 = peg$literalExpectation(">", false),
-      peg$c85 = "!=",
-      peg$c86 = peg$literalExpectation("!=", false),
-      peg$c87 = function() { return text(); },
-      peg$c88 = function(expr) {
+      peg$c78 = "=",
+      peg$c79 = peg$literalExpectation("=", false),
+      peg$c80 = "<=",
+      peg$c81 = peg$literalExpectation("<=", false),
+      peg$c82 = ">=",
+      peg$c83 = peg$literalExpectation(">=", false),
+      peg$c84 = "<",
+      peg$c85 = peg$literalExpectation("<", false),
+      peg$c86 = ">",
+      peg$c87 = peg$literalExpectation(">", false),
+      peg$c88 = "!=",
+      peg$c89 = peg$literalExpectation("!=", false),
+      peg$c90 = function() { return text(); },
+      peg$c91 = function(expr) {
         return {
           paren: expr
         }
       },
-      peg$c89 = "\"",
-      peg$c90 = peg$literalExpectation("\"", false),
-      peg$c91 = function(chars) {
+      peg$c92 = "\"",
+      peg$c93 = peg$literalExpectation("\"", false),
+      peg$c94 = function(chars) {
           return {quoted:chars.join('')};  
         },
-      peg$c92 = "\\",
-      peg$c93 = peg$literalExpectation("\\", false),
-      peg$c94 = function() { return '"'; },
-      peg$c95 = /^[^.\u1409\u1405()|,\u039B=${}<>! \n]/,
-      peg$c96 = peg$classExpectation([".", "\u1409", "\u1405", "(", ")", "|", ",", "\u039B", "=", "$", "{", "}", "<", ">", "!", " ", "\n"], true, false),
-      peg$c97 = function() {
+      peg$c95 = "\\",
+      peg$c96 = peg$literalExpectation("\\", false),
+      peg$c97 = function() { return '"'; },
+      peg$c98 = /^[^.\u1409\u1405()|,\u039B=${}<>! \n]/,
+      peg$c99 = peg$classExpectation([".", "\u1409", "\u1405", "(", ")", "|", ",", "\u039B", "=", "$", "{", "}", "<", ">", "!", " ", "\n"], true, false),
+      peg$c100 = function() {
         return text();
       },
-      peg$c98 = ".",
-      peg$c99 = peg$literalExpectation(".", false),
-      peg$c100 = "\u1405",
-      peg$c101 = peg$literalExpectation("\u1405", false),
-      peg$c102 = /^[ \n\t]/,
-      peg$c103 = peg$classExpectation([" ", "\n", "\t"], false, false),
+      peg$c101 = ".",
+      peg$c102 = peg$literalExpectation(".", false),
+      peg$c103 = "\u1405",
+      peg$c104 = peg$literalExpectation("\u1405", false),
+      peg$c105 = /^[ \n\t]/,
+      peg$c106 = peg$classExpectation([" ", "\n", "\t"], false, false),
 
       peg$currPos          = 0,
       peg$savedPos         = 0,
@@ -1489,16 +1496,87 @@ function peg$parse(input, options) {
     return s0;
   }
 
+  function peg$parseSplitExpression() {
+    var s0, s1, s2, s3, s4, s5, s6, s7;
+
+    s0 = peg$currPos;
+    if (input.substr(peg$currPos, 5) === peg$c69) {
+      s1 = peg$c69;
+      peg$currPos += 5;
+    } else {
+      s1 = peg$FAILED;
+      if (peg$silentFails === 0) { peg$fail(peg$c70); }
+    }
+    if (s1 !== peg$FAILED) {
+      s2 = peg$parse_();
+      if (s2 !== peg$FAILED) {
+        if (input.charCodeAt(peg$currPos) === 40) {
+          s3 = peg$c47;
+          peg$currPos++;
+        } else {
+          s3 = peg$FAILED;
+          if (peg$silentFails === 0) { peg$fail(peg$c48); }
+        }
+        if (s3 !== peg$FAILED) {
+          s4 = peg$parse_();
+          if (s4 !== peg$FAILED) {
+            s5 = peg$parsePathList();
+            if (s5 !== peg$FAILED) {
+              s6 = peg$parse_();
+              if (s6 !== peg$FAILED) {
+                if (input.charCodeAt(peg$currPos) === 41) {
+                  s7 = peg$c15;
+                  peg$currPos++;
+                } else {
+                  s7 = peg$FAILED;
+                  if (peg$silentFails === 0) { peg$fail(peg$c16); }
+                }
+                if (s7 !== peg$FAILED) {
+                  peg$savedPos = s0;
+                  s1 = peg$c71(s1, s5);
+                  s0 = s1;
+                } else {
+                  peg$currPos = s0;
+                  s0 = peg$FAILED;
+                }
+              } else {
+                peg$currPos = s0;
+                s0 = peg$FAILED;
+              }
+            } else {
+              peg$currPos = s0;
+              s0 = peg$FAILED;
+            }
+          } else {
+            peg$currPos = s0;
+            s0 = peg$FAILED;
+          }
+        } else {
+          peg$currPos = s0;
+          s0 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+    } else {
+      peg$currPos = s0;
+      s0 = peg$FAILED;
+    }
+
+    return s0;
+  }
+
   function peg$parseIf() {
     var s0, s1, s2, s3, s4, s5, s6, s7, s8, s9;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 3) === peg$c69) {
-      s1 = peg$c69;
+    if (input.substr(peg$currPos, 3) === peg$c72) {
+      s1 = peg$c72;
       peg$currPos += 3;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c70); }
+      if (peg$silentFails === 0) { peg$fail(peg$c73); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
@@ -1527,7 +1605,7 @@ function peg$parse(input, options) {
                     }
                     if (s9 !== peg$FAILED) {
                       peg$savedPos = s0;
-                      s1 = peg$c71(s3, s5, s7);
+                      s1 = peg$c74(s3, s5, s7);
                       s0 = s1;
                     } else {
                       peg$currPos = s0;
@@ -1579,6 +1657,9 @@ function peg$parse(input, options) {
         s0 = peg$parseCqExpression();
         if (s0 === peg$FAILED) {
           s0 = peg$parseIf();
+          if (s0 === peg$FAILED) {
+            s0 = peg$parseSplitExpression();
+          }
         }
       }
     }
@@ -1593,7 +1674,7 @@ function peg$parse(input, options) {
     s1 = peg$parseOperation();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c72(s1);
+      s1 = peg$c75(s1);
     }
     s0 = s1;
 
@@ -1622,7 +1703,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c72(s1);
+      s1 = peg$c75(s1);
     }
     s0 = s1;
 
@@ -1675,7 +1756,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c73(s1, s2);
+        s1 = peg$c76(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -1707,7 +1788,7 @@ function peg$parse(input, options) {
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c74(s1, s3, s5);
+              s1 = peg$c77(s1, s3, s5);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -1737,56 +1818,56 @@ function peg$parse(input, options) {
     var s0, s1;
 
     if (input.charCodeAt(peg$currPos) === 61) {
-      s0 = peg$c75;
+      s0 = peg$c78;
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c76); }
+      if (peg$silentFails === 0) { peg$fail(peg$c79); }
     }
     if (s0 === peg$FAILED) {
-      if (input.substr(peg$currPos, 2) === peg$c77) {
-        s0 = peg$c77;
+      if (input.substr(peg$currPos, 2) === peg$c80) {
+        s0 = peg$c80;
         peg$currPos += 2;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c78); }
+        if (peg$silentFails === 0) { peg$fail(peg$c81); }
       }
       if (s0 === peg$FAILED) {
-        if (input.substr(peg$currPos, 2) === peg$c79) {
-          s0 = peg$c79;
+        if (input.substr(peg$currPos, 2) === peg$c82) {
+          s0 = peg$c82;
           peg$currPos += 2;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c80); }
+          if (peg$silentFails === 0) { peg$fail(peg$c83); }
         }
         if (s0 === peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 60) {
-            s0 = peg$c81;
+            s0 = peg$c84;
             peg$currPos++;
           } else {
             s0 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c82); }
+            if (peg$silentFails === 0) { peg$fail(peg$c85); }
           }
           if (s0 === peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 62) {
-              s0 = peg$c83;
+              s0 = peg$c86;
               peg$currPos++;
             } else {
               s0 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c84); }
+              if (peg$silentFails === 0) { peg$fail(peg$c87); }
             }
             if (s0 === peg$FAILED) {
               s0 = peg$currPos;
-              if (input.substr(peg$currPos, 2) === peg$c85) {
-                s1 = peg$c85;
+              if (input.substr(peg$currPos, 2) === peg$c88) {
+                s1 = peg$c88;
                 peg$currPos += 2;
               } else {
                 s1 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c86); }
+                if (peg$silentFails === 0) { peg$fail(peg$c89); }
               }
               if (s1 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c87();
+                s1 = peg$c90();
               }
               s0 = s1;
             }
@@ -1832,7 +1913,7 @@ function peg$parse(input, options) {
         }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c88(s2);
+          s1 = peg$c91(s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -1855,11 +1936,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 34) {
-      s1 = peg$c89;
+      s1 = peg$c92;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c90); }
+      if (peg$silentFails === 0) { peg$fail(peg$c93); }
     }
     if (s1 !== peg$FAILED) {
       s2 = [];
@@ -1870,15 +1951,15 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 34) {
-          s3 = peg$c89;
+          s3 = peg$c92;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c90); }
+          if (peg$silentFails === 0) { peg$fail(peg$c93); }
         }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c91(s2);
+          s1 = peg$c94(s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -1901,23 +1982,23 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 92) {
-      s1 = peg$c92;
+      s1 = peg$c95;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c93); }
+      if (peg$silentFails === 0) { peg$fail(peg$c96); }
     }
     if (s1 !== peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 34) {
-        s2 = peg$c89;
+        s2 = peg$c92;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c90); }
+        if (peg$silentFails === 0) { peg$fail(peg$c93); }
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c94();
+        s1 = peg$c97();
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -1932,11 +2013,11 @@ function peg$parse(input, options) {
       s1 = peg$currPos;
       peg$silentFails++;
       if (input.charCodeAt(peg$currPos) === 34) {
-        s2 = peg$c89;
+        s2 = peg$c92;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c90); }
+        if (peg$silentFails === 0) { peg$fail(peg$c93); }
       }
       peg$silentFails--;
       if (s2 === peg$FAILED) {
@@ -1955,7 +2036,7 @@ function peg$parse(input, options) {
         }
         if (s2 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c87();
+          s1 = peg$c90();
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -1975,22 +2056,22 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     s1 = [];
-    if (peg$c95.test(input.charAt(peg$currPos))) {
+    if (peg$c98.test(input.charAt(peg$currPos))) {
       s2 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s2 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c96); }
+      if (peg$silentFails === 0) { peg$fail(peg$c99); }
     }
     if (s2 !== peg$FAILED) {
       while (s2 !== peg$FAILED) {
         s1.push(s2);
-        if (peg$c95.test(input.charAt(peg$currPos))) {
+        if (peg$c98.test(input.charAt(peg$currPos))) {
           s2 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c96); }
+          if (peg$silentFails === 0) { peg$fail(peg$c99); }
         }
       }
     } else {
@@ -1998,7 +2079,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c97();
+      s1 = peg$c100();
     }
     s0 = s1;
 
@@ -2012,11 +2093,11 @@ function peg$parse(input, options) {
     s1 = peg$parse_();
     if (s1 !== peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 46) {
-        s2 = peg$c98;
+        s2 = peg$c101;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c99); }
+        if (peg$silentFails === 0) { peg$fail(peg$c102); }
       }
       if (s2 === peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 5129) {
@@ -2028,11 +2109,11 @@ function peg$parse(input, options) {
         }
         if (s2 === peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 5125) {
-            s2 = peg$c100;
+            s2 = peg$c103;
             peg$currPos++;
           } else {
             s2 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c101); }
+            if (peg$silentFails === 0) { peg$fail(peg$c104); }
           }
         }
       }
@@ -2061,21 +2142,21 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = [];
-    if (peg$c102.test(input.charAt(peg$currPos))) {
+    if (peg$c105.test(input.charAt(peg$currPos))) {
       s1 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c103); }
+      if (peg$silentFails === 0) { peg$fail(peg$c106); }
     }
     while (s1 !== peg$FAILED) {
       s0.push(s1);
-      if (peg$c102.test(input.charAt(peg$currPos))) {
+      if (peg$c105.test(input.charAt(peg$currPos))) {
         s1 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c103); }
+        if (peg$silentFails === 0) { peg$fail(peg$c106); }
       }
     }
 

--- a/build/pegjs-parser.js
+++ b/build/pegjs-parser.js
@@ -251,11 +251,14 @@ function peg$parse(input, options) {
           cq: path
         }
       },
-      peg$c69 = "split",
-      peg$c70 = peg$literalExpectation("split", false),
-      peg$c71 = function(operation, path) {
+      peg$c69 = "split(",
+      peg$c70 = peg$literalExpectation("split(", false),
+      peg$c71 = function(thingToSplit, splitBy) {
         return {
-          split: path
+          split: {
+            thingToSplit,
+            splitBy
+          }
         }
       },
       peg$c72 = "if(",
@@ -1497,12 +1500,12 @@ function peg$parse(input, options) {
   }
 
   function peg$parseSplitExpression() {
-    var s0, s1, s2, s3, s4, s5, s6, s7;
+    var s0, s1, s2, s3, s4, s5, s6, s7, s8, s9;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 5) === peg$c69) {
+    if (input.substr(peg$currPos, 6) === peg$c69) {
       s1 = peg$c69;
-      peg$currPos += 5;
+      peg$currPos += 6;
     } else {
       s1 = peg$FAILED;
       if (peg$silentFails === 0) { peg$fail(peg$c70); }
@@ -1510,31 +1513,43 @@ function peg$parse(input, options) {
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
       if (s2 !== peg$FAILED) {
-        if (input.charCodeAt(peg$currPos) === 40) {
-          s3 = peg$c47;
-          peg$currPos++;
-        } else {
-          s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c48); }
-        }
+        s3 = peg$parseEquationPart();
         if (s3 !== peg$FAILED) {
           s4 = peg$parse_();
           if (s4 !== peg$FAILED) {
-            s5 = peg$parsePathList();
+            s5 = peg$parsePathSeparator();
+            if (s5 === peg$FAILED) {
+              s5 = null;
+            }
             if (s5 !== peg$FAILED) {
               s6 = peg$parse_();
               if (s6 !== peg$FAILED) {
-                if (input.charCodeAt(peg$currPos) === 41) {
-                  s7 = peg$c15;
-                  peg$currPos++;
-                } else {
-                  s7 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c16); }
+                s7 = peg$parseEquationPart();
+                if (s7 === peg$FAILED) {
+                  s7 = null;
                 }
                 if (s7 !== peg$FAILED) {
-                  peg$savedPos = s0;
-                  s1 = peg$c71(s1, s5);
-                  s0 = s1;
+                  s8 = peg$parse_();
+                  if (s8 !== peg$FAILED) {
+                    if (input.charCodeAt(peg$currPos) === 41) {
+                      s9 = peg$c15;
+                      peg$currPos++;
+                    } else {
+                      s9 = peg$FAILED;
+                      if (peg$silentFails === 0) { peg$fail(peg$c16); }
+                    }
+                    if (s9 !== peg$FAILED) {
+                      peg$savedPos = s0;
+                      s1 = peg$c71(s3, s7);
+                      s0 = s1;
+                    } else {
+                      peg$currPos = s0;
+                      s0 = peg$FAILED;
+                    }
+                  } else {
+                    peg$currPos = s0;
+                    s0 = peg$FAILED;
+                  }
                 } else {
                   peg$currPos = s0;
                   s0 = peg$FAILED;

--- a/conditional.js
+++ b/conditional.js
@@ -132,6 +132,9 @@ function generateEvaluateConditionFn(self, ast, $global, _filters, $valueFn, pip
       return item => {
         let promises = fns.map(fn => fn(item));
         return Promise.all(promises).then(([thingToSplit,splitBy]) => {
+          // It's possible that splitBy will be empty.  For example, if you specify a field for splitBy, it will
+          // get evaluated for each record, and some records may not have that field.  In such a case, we don't
+          // want to use a default comma.
           if (thingToSplit && splitBy) {
             if (typeof thingToSplit === "string") {
               return thingToSplit.split(splitBy);

--- a/conditional.js
+++ b/conditional.js
@@ -121,6 +121,25 @@ function generateEvaluateConditionFn(self, ast, $global, _filters, $valueFn, pip
         return values;
       });
     }
+    if (typeof target === "object" && target.split) {
+      let separator = ",";
+      const arg = target.split[0];
+      let path;
+      if (typeof arg === "string") {
+        path = arg;
+      } else if (typeof arg === "object" && arg.piped && arg.piped.length > 1) {
+        path = arg.piped[0];
+        separator = arg.piped[1].replace(/^["'](.+(?=["']$))["']$/, '$1'); // strip quotes
+      } else {
+        return;
+      }
+      return item => clues(item, path, $global).then(values => {
+        if (typeof values === "string") {
+          return values.split(separator);
+        }
+        return values;
+      });
+    }
     if (target.math) {
       let fns = target.math.piped.map(node => generateEvaluateConditionFn(self, node, $global, _filters, $valueFn));
       let accumulator = null;

--- a/conditional.js
+++ b/conditional.js
@@ -130,9 +130,7 @@ function generateEvaluateConditionFn(self, ast, $global, _filters, $valueFn, pip
       } else if (typeof arg === "object" && arg.piped && arg.piped.length > 1) {
         path = arg.piped[0];
         separator = arg.piped[1].replace(/^["'](.+(?=["']$))["']$/, '$1'); // strip quotes
-      } else {
-        return;
-      }
+      } 
       return item => clues(item, path, $global).then(values => {
         if (typeof values === "string") {
           return values.split(separator);

--- a/conditional.js
+++ b/conditional.js
@@ -137,14 +137,20 @@ function generateEvaluateConditionFn(self, ast, $global, _filters, $valueFn, pip
       // Evaluate any parens in tree
       const ps = paths.map(p => {
         if (p.paren) {
-          return generateEvaluateConditionFn(self, p.paren, $global, _filters, $valueFn);
+          return generateEvaluateConditionFn(self, p, $global, _filters, $valueFn);
         } else {
-          return Promise.resolve(p);
+          return p;
         }
       });
       return item => {
-        return Promise.all(ps).then(p => {
-          let path = astToCluesPath(p); 
+        const promiseArray = ps.map(p => {
+          if (typeof p === 'function') {
+            return p(item);
+          }
+          return Promise.resolve(p);
+        });
+        return Promise.all(promiseArray).then(paths => {
+          let path = astToCluesPath(paths);
           return clues(item, path, $global).then(values => {
             if (typeof values === "string") {
               return values.split(separator);

--- a/conditional.js
+++ b/conditional.js
@@ -122,15 +122,11 @@ function generateEvaluateConditionFn(self, ast, $global, _filters, $valueFn, pip
       });
     }
     if (typeof target === "object" && target.split) {
-      let separator = ",";
-      const arg = target.split[0];
-      let path;
-      if (typeof arg === "string") {
-        path = arg;
-      } else if (typeof arg === "object" && arg.piped && arg.piped.length > 1) {
-        path = arg.piped[0];
-        separator = arg.piped[1].replace(/^["'](.+(?=["']$))["']$/, '$1'); // strip quotes
-      } 
+      let reconstitutedPath = astToCluesPath(target.split);
+      let [ optClause, optSeparator] = reconstitutedPath.match(/(?:,([^),]+))?$/); /* Use the last comma outside parens to determine any optional separator */
+      let path = optClause ? reconstitutedPath.slice(0,-optClause.length) : reconstitutedPath;
+      let separator = optSeparator || ",";
+      separator = separator.replace(/^["'](.+(?=["']$))["']$/, '$1'); // strip quotes
       return item => clues(item, path, $global).then(values => {
         if (typeof values === "string") {
           return values.split(separator);

--- a/conditional.js
+++ b/conditional.js
@@ -137,7 +137,7 @@ function generateEvaluateConditionFn(self, ast, $global, _filters, $valueFn, pip
               return thingToSplit.split(splitBy);
             }  
           }
-        return thingToSplit;
+          return thingToSplit;
         });
       };
     }

--- a/index.js
+++ b/index.js
@@ -487,18 +487,6 @@ Query.connect = function() {
     }).join('');
 };
 
-Query.split = function() {
-  if (this.length) {
-    return this.filter(function(d) {
-      return typeof d === "string";
-    })
-    .map(function(d) {
-      return d.split(',');
-    })
-    .flat();
-  }
-}
-
 function definedHelperProperty(key, value) {
   Object.defineProperty(Query,key,{
     value,

--- a/index.js
+++ b/index.js
@@ -487,6 +487,18 @@ Query.connect = function() {
     }).join('');
 };
 
+Query.split = function() {
+  if (this.length) {
+    return this.filter(function(d) {
+      return typeof d === "string";
+    })
+    .map(function(d) {
+      return d.split(',');
+    })
+    .flat();
+  }
+}
+
 function definedHelperProperty(key, value) {
   Object.defineProperty(Query,key,{
     value,

--- a/paths.pegjs
+++ b/paths.pegjs
@@ -79,6 +79,12 @@ CqExpression = operation:("cq") _ "(" _ path:Expression _ ")" {
   }
 }
 
+SplitExpression = operation:("split") _ "(" _ path:Expression _ ")" {
+  return {
+    split: path
+  }
+}
+
 If = "if(" _ condition:(Equation / ParenExpr) PathSeparator ifTrue:EquationPart PathSeparator ifFalse:EquationPart _ ")" { return { 
     if: {
       condition, ifTrue, ifFalse
@@ -86,7 +92,7 @@ If = "if(" _ condition:(Equation / ParenExpr) PathSeparator ifTrue:EquationPart 
   }; 
 }
 
-Operation = MathExpression / DateOperation / CqExpression / If
+Operation = MathExpression / DateOperation / CqExpression / If / SplitExpression
 TopLevelOperation = equationPart:Operation {
   return { equationPart }
 }

--- a/paths.pegjs
+++ b/paths.pegjs
@@ -79,9 +79,12 @@ CqExpression = operation:("cq") _ "(" _ path:Expression _ ")" {
   }
 }
 
-SplitExpression = operation:("split") _ "(" _ path:Expression _ ")" {
+SplitExpression = "split(" _ thingToSplit:EquationPart _ PathSeparator? _ splitBy:EquationPart? _ ")" {
   return {
-    split: path
+    split: {
+      thingToSplit,
+      splitBy
+    }
   }
 }
 

--- a/test/ast-test.js
+++ b/test/ast-test.js
@@ -24,6 +24,7 @@ module.exports = t => {
   confirmMatches('property.residential.something.add(someweird,(fsde.sjdrfkl.fsdjkl)|sub(5,(cq(a.b).solve.add((a.b.d), if((a.b.c=5),"yo",${someNestedThing}),3,2)))).foop.deeper');
   confirmMatches('where.in(test2, arr(b, "C"))');
   confirmMatches('where.addyears(addmonths(adddays(testDate,4),3),-1)=date("2019-07-05 12:13:15 pm")');
+  confirmMatches('select.split((deep.deeper.deepest),"^")');
 
   // this has tabs in it! ON PURPOSE
   confirmMatches(`property.

--- a/test/join-test.js
+++ b/test/join-test.js
@@ -6,7 +6,7 @@ var clues = require('clues'),
 data = Object.create(data);
 
 data2 = Object.setPrototypeOf([
-  { joined: 'a,b,c', nonstrings: 13 },
+  { joined: 'a,b,c', nonstrings: 13, deeper: { joined: 'j,k,l^q', joined2: '3^k'} },
   6,
   Promise.resolve({ joined: 'c,d,e', nonstrings: { a: 1 }}),
   { joined: 'asdf', nonstrings: undefined },
@@ -59,6 +59,27 @@ t.test('split',{autoend:true}, function(t) {
         t.same(d, [['a,b,c'],undefined,['c,d,e'],['a','df'],undefined,undefined,undefined,undefined,undefined],'Correct output for alternate split');
       });
   });
+  t.test('works with deeper paths',{autoend:true},function(t) {
+    return clues(data2,'select.split(deeper.joined,"^")')
+      .then(function(d) {
+        t.same(d, [['j,k,l','q'],undefined,undefined,undefined,undefined,undefined,undefined,undefined,undefined],'Deeper paths');
+      })
+      .catch(e => {
+        console.log(e);
+      });
+  });
+
+  /* Why doesn't this work?  clues(facts, 'deeper.joined') works but clues(facts, '(deeper.joined)') does not. */
+  // t.test('works with multiple deeper paths',{autoend:true},function(t) {
+  //   return clues(data2,'select.split((deeper.joined),"^")')
+  //     .then(function(d) {
+  //       t.same(d, [['j,k,l','q'],undefined,undefined,undefined,undefined,undefined,undefined,undefined,undefined],'Deeper paths');
+  //     })
+  //     .catch(e => {
+  //       console.log(e);
+  //     });
+  // });
+
   t.test('splitting non-strings simply returns the field',{autoend:true},function(t) {
     return clues(data2,'select.split(nonstrings)')
       .then(function(d) {

--- a/test/join-test.js
+++ b/test/join-test.js
@@ -5,6 +5,18 @@ var clues = require('clues'),
 
 data = Object.create(data);
 
+data2 = Object.setPrototypeOf([
+  { joined: 'a,b,c' },
+  6,
+  Promise.resolve({ joined: 'c,d,e'}),
+  { joined: 'asdf' },
+  null,
+  "some string",
+  undefined,
+  false,
+  0
+], Query);
+
 module.exports = t => {
 
 t.test('join',{autoend:true},function(t) {
@@ -21,6 +33,16 @@ t.test('connect',{autoend:true},function(t) {
     return clues(data,'select.Value.connect')
       .then(function(d) {
         t.same(d,'55NOT NUMBER81697210010092100878256827176100879210087814186797810095961007781');
+      });
+  });
+});
+
+t.test('split',{autoend:true}, function(t) {
+  t.test('uses , as a default separator',{autoend:true},function(t) {
+    return clues(data2,'select.joined.split')
+      .then(function(d) {
+        t.same(d.length,7,'Correct length for split');
+        t.same(d, ['a','b','c','c','d','e','asdf'],'Correct output for split');
       });
   });
 });

--- a/test/join-test.js
+++ b/test/join-test.js
@@ -6,7 +6,7 @@ var clues = require('clues'),
 data = Object.create(data);
 
 data2 = Object.setPrototypeOf([
-  { joined: 'a,b,c', nonstrings: 13, deep: { 
+  { joined: 'a,b,c', nonstrings: 13, conjoined: 'g,h,i', deep: { 
     joined: 'j,k,l^q', paren: 'joined', deeper: { deeperer: { deeperest: { joined: 'x^y^z'}}}}},
   6,
   Promise.resolve({ joined: 'c,d,e', nonstrings: { a: 1 }}),
@@ -63,7 +63,6 @@ t.test('split',{autoend:true}, function(t) {
         t.same(d, [['x','y','z'],undefined,undefined,undefined,undefined,undefined,undefined,undefined,undefined],'Deeper paths');
       });
   });
-
   t.test('splitting non-strings simply returns the field',{autoend:true},function(t) {
     return clues(data2,'select.split(nonstrings)')
       .then(function(d) {

--- a/test/join-test.js
+++ b/test/join-test.js
@@ -6,10 +6,10 @@ var clues = require('clues'),
 data = Object.create(data);
 
 data2 = Object.setPrototypeOf([
-  { joined: 'a,b,c' },
+  { joined: 'a,b,c', nonstrings: 13 },
   6,
-  Promise.resolve({ joined: 'c,d,e'}),
-  { joined: 'asdf' },
+  Promise.resolve({ joined: 'c,d,e', nonstrings: { a: 1 }}),
+  { joined: 'asdf', nonstrings: undefined },
   null,
   "some string",
   undefined,
@@ -52,6 +52,30 @@ t.test('split',{autoend:true}, function(t) {
       .then(function(d) {
         t.same(d, [['a,b,c'],undefined,['c,d,e'],['a','df'],undefined,undefined,undefined,undefined,undefined],'Correct output for alternate split');
       });
+  });
+  t.test('alternate separator works without quotes',{autoend:true},function(t) {
+    return clues(data2,'select.split(joined,s)')
+      .then(function(d) {
+        t.same(d, [['a,b,c'],undefined,['c,d,e'],['a','df'],undefined,undefined,undefined,undefined,undefined],'Correct output for alternate split');
+      });
+  });
+  t.test('splitting non-strings simply returns the field',{autoend:true},function(t) {
+    return clues(data2,'select.split(nonstrings)')
+      .then(function(d) {
+        t.same(d, [13,undefined,{a: 1},undefined,undefined,undefined,undefined,undefined,undefined], 'Splitting non-strings');
+      });
+  });
+  t.test('ignores if not called as an operation',{autoend:true},function(t) {
+    return clues(data2,'select.split')
+      .then(function(d) {
+        t.same(d.length, 9, 'non-operation does not break');
+        d.forEach(c => {
+          t.same(c, undefined, 'non-operation does not break for each record');
+        });
+      });
+  });
+  t.test('will reject if invoked with no operands',{autoend:true},function(t) {
+    return t.rejects(clues(data2,'select.split()'));
   });
 });
 };

--- a/test/join-test.js
+++ b/test/join-test.js
@@ -45,6 +45,13 @@ t.test('split',{autoend:true}, function(t) {
         t.same(d, ['a','b','c','c','d','e','asdf'],'Correct output for split');
       });
   });
+  t.test('can specify an alternate separator',{autoend:true},function(t) {
+    return clues(data2,'select.joined.split.s')
+      .then(function(d) {
+        t.same(d.length,4,'Correct length for alternate split');
+        t.same(d, ['a,b,c','c,d,e','a','df'],'Correct output for alternate split');
+      });
+  });
 });
 };
 

--- a/test/join-test.js
+++ b/test/join-test.js
@@ -6,7 +6,8 @@ var clues = require('clues'),
 data = Object.create(data);
 
 data2 = Object.setPrototypeOf([
-  { joined: 'a,b,c', nonstrings: 13, deeper: { joined: 'j,k,l^q', joined2: '3^k'} },
+  { joined: 'a,b,c', nonstrings: 13, deep: { 
+    joined: 'j,k,l^q', paren: 'joined', deeper: { deeperer: { deeperest: { joined: 'x^y^z'}}}}},
   6,
   Promise.resolve({ joined: 'c,d,e', nonstrings: { a: 1 }}),
   { joined: 'asdf', nonstrings: undefined },
@@ -56,20 +57,25 @@ t.test('split',{autoend:true}, function(t) {
         t.same(d, [['a,b,c'],undefined,['c,d,e'],['a','df'],undefined,undefined,undefined,undefined,undefined],'Correct output for alternate split');
       });
   });
-  // t.test('works with deeper paths',{autoend:true},function(t) {
-  //   return clues(data2,'select.split(deep.deeper.deeperer.deeperest.joined,"^")')
-  //     .then(function(d) {
-  //       t.same(d, [['j,k,l','q'],undefined,undefined,undefined,undefined,undefined,undefined,undefined,undefined],'Deeper paths');
-  //     });
-  // });
+  t.test('works with deeper paths',{autoend:true},function(t) {
+    return clues(data2,'select.split(deep.deeper.deeperer.deeperest.joined,"^")')
+      .then(function(d) {
+        t.same(d, [['x','y','z'],undefined,undefined,undefined,undefined,undefined,undefined,undefined,undefined],'Deeper paths');
+      });
+  });
 
-  /* Why doesn't this work?  clues(facts, 'deeper.joined') works but clues(facts, '(deeper.joined)') does not. */
-  // t.test('works with multiple deeper paths',{autoend:true},function(t) {
-  //   return clues(data2,'select.split((deeper.joined),"^")')
-  //     .then(function(d) {
-  //       t.same(d, [['j,k,l','q'],undefined,undefined,undefined,undefined,undefined,undefined,undefined,undefined],'Deeper paths');
-  //     });
-  // });
+  t.test('works with nested deeper paths',{autoend:true},function(t) {
+    return clues(data2,'select.split((deep.paren))')
+      .then(function(d) {
+        t.same(d, [['a','b','c'],undefined,undefined,undefined,undefined,undefined,undefined,undefined,undefined],'Correct output for alternate split');
+      });
+  });
+  t.test('works with nested deeper paths with optional separator',{autoend:true},function(t) {
+    return clues(data2,'select.split((deep.paren),"b")')
+      .then(function(d) {
+        t.same(d, [['a,',',c'],undefined,undefined,undefined,undefined,undefined,undefined,undefined,undefined],'Correct output for alternate split');
+      });
+  });
 
   t.test('splitting non-strings simply returns the field',{autoend:true},function(t) {
     return clues(data2,'select.split(nonstrings)')

--- a/test/join-test.js
+++ b/test/join-test.js
@@ -10,7 +10,7 @@ data2 = Object.setPrototypeOf([
     joined: 'j,k,l^q', paren: 'joined', deeper: { deeperer: { deeperest: { joined: 'x^y^z'}}}}},
   6,
   Promise.resolve({ joined: 'c,d,e', nonstrings: { a: 1 }}),
-  { joined: 'asdf', nonstrings: undefined },
+  { joined: 'asdf', nonstrings: undefined, separator: 's' },
   null,
   "some string",
   undefined,
@@ -51,29 +51,16 @@ t.test('split',{autoend:true}, function(t) {
         t.same(d, [['a,b,c'],undefined,['c,d,e'],['a','df'],undefined,undefined,undefined,undefined,undefined],'Correct output for alternate split');
       });
   });
-  t.test('alternate separator works without quotes',{autoend:true},function(t) {
-    return clues(data2,'select.split(joined,s)')
+  t.test('alternate separator without quotes is evaluated',{autoend:true},function(t) {
+    return clues(data2,'select.split(joined,separator)')
       .then(function(d) {
-        t.same(d, [['a,b,c'],undefined,['c,d,e'],['a','df'],undefined,undefined,undefined,undefined,undefined],'Correct output for alternate split');
+        t.same(d, ['a,b,c',undefined,'c,d,e',['a','df'],undefined,undefined,undefined,undefined,undefined],'Correct output for alternate split');
       });
   });
   t.test('works with deeper paths',{autoend:true},function(t) {
-    return clues(data2,'select.split(deep.deeper.deeperer.deeperest.joined,"^")')
+    return clues(data2,'select.split((deep.deeper.deeperer.deeperest.joined),"^")')
       .then(function(d) {
         t.same(d, [['x','y','z'],undefined,undefined,undefined,undefined,undefined,undefined,undefined,undefined],'Deeper paths');
-      });
-  });
-
-  t.test('works with nested deeper paths',{autoend:true},function(t) {
-    return clues(data2,'select.split((deep.paren))')
-      .then(function(d) {
-        t.same(d, [['a','b','c'],undefined,undefined,undefined,undefined,undefined,undefined,undefined,undefined],'Correct output for alternate split');
-      });
-  });
-  t.test('works with nested deeper paths with optional separator',{autoend:true},function(t) {
-    return clues(data2,'select.split((deep.paren),"b")')
-      .then(function(d) {
-        t.same(d, [['a,',',c'],undefined,undefined,undefined,undefined,undefined,undefined,undefined,undefined],'Correct output for alternate split');
       });
   });
 

--- a/test/join-test.js
+++ b/test/join-test.js
@@ -42,9 +42,6 @@ t.test('split',{autoend:true}, function(t) {
     return clues(data2,'select.split(joined)')
       .then(function(d) {
         t.same(d, [['a','b','c'],undefined,['c','d','e'],['asdf'],undefined,undefined,undefined,undefined,undefined],'Correct output for split');
-      })
-      .catch(e => {
-        console.log('problem', e);
       });
   });
   t.test('can specify an alternate separator',{autoend:true},function(t) {
@@ -59,24 +56,18 @@ t.test('split',{autoend:true}, function(t) {
         t.same(d, [['a,b,c'],undefined,['c,d,e'],['a','df'],undefined,undefined,undefined,undefined,undefined],'Correct output for alternate split');
       });
   });
-  t.test('works with deeper paths',{autoend:true},function(t) {
-    return clues(data2,'select.split(deeper.joined,"^")')
-      .then(function(d) {
-        t.same(d, [['j,k,l','q'],undefined,undefined,undefined,undefined,undefined,undefined,undefined,undefined],'Deeper paths');
-      })
-      .catch(e => {
-        console.log(e);
-      });
-  });
+  // t.test('works with deeper paths',{autoend:true},function(t) {
+  //   return clues(data2,'select.split(deep.deeper.deeperer.deeperest.joined,"^")')
+  //     .then(function(d) {
+  //       t.same(d, [['j,k,l','q'],undefined,undefined,undefined,undefined,undefined,undefined,undefined,undefined],'Deeper paths');
+  //     });
+  // });
 
   /* Why doesn't this work?  clues(facts, 'deeper.joined') works but clues(facts, '(deeper.joined)') does not. */
   // t.test('works with multiple deeper paths',{autoend:true},function(t) {
   //   return clues(data2,'select.split((deeper.joined),"^")')
   //     .then(function(d) {
   //       t.same(d, [['j,k,l','q'],undefined,undefined,undefined,undefined,undefined,undefined,undefined,undefined],'Deeper paths');
-  //     })
-  //     .catch(e => {
-  //       console.log(e);
   //     });
   // });
 

--- a/test/join-test.js
+++ b/test/join-test.js
@@ -39,17 +39,18 @@ t.test('connect',{autoend:true},function(t) {
 
 t.test('split',{autoend:true}, function(t) {
   t.test('uses , as a default separator',{autoend:true},function(t) {
-    return clues(data2,'select.joined.split')
+    return clues(data2,'select.split(joined)')
       .then(function(d) {
-        t.same(d.length,7,'Correct length for split');
-        t.same(d, ['a','b','c','c','d','e','asdf'],'Correct output for split');
+        t.same(d, [['a','b','c'],undefined,['c','d','e'],['asdf'],undefined,undefined,undefined,undefined,undefined],'Correct output for split');
+      })
+      .catch(e => {
+        console.log('problem', e);
       });
   });
   t.test('can specify an alternate separator',{autoend:true},function(t) {
-    return clues(data2,'select.joined.split.s')
+    return clues(data2,'select.split(joined,"s")')
       .then(function(d) {
-        t.same(d.length,4,'Correct length for alternate split');
-        t.same(d, ['a,b,c','c,d,e','a','df'],'Correct output for alternate split');
+        t.same(d, [['a,b,c'],undefined,['c,d,e'],['a','df'],undefined,undefined,undefined,undefined,undefined],'Correct output for alternate split');
       });
   });
 });


### PR DESCRIPTION
This is a work-in-progress.  

I don't understand yet why putting parens around the path makes it not work.  For example, `split(deeper.join,'^')` works but `split((deeper.join),'^')` does not.  Using `(deeper.join)` as a clues path does not seem to work.  I assume I have to handle any parens myself before going to clues, but if I look at other operations, like `cq`, they don't seem to do any separate handling of parens.