### PR TITLE
Null stats

### DIFF
--- a/index.js
+++ b/index.js
@@ -403,7 +403,8 @@ Query.stats = function() {
     median : null,
     sum : null,
     min: null,
-    max: null
+    max: null,
+    avg: null
   });
   if (!isNaN(stats.sum) && !isNaN(stats.count) && stats.count > 0) {
     stats.avg = stats.sum / stats.count;

--- a/index.js
+++ b/index.js
@@ -400,7 +400,10 @@ Query.stats = function() {
   },{
     cumul : [],
     count : 0,
-    median : undefined
+    median : null,
+    sum : null,
+    min: null,
+    max: null
   });
   if (!isNaN(stats.sum) && !isNaN(stats.count) && stats.count > 0) {
     stats.avg = stats.sum / stats.count;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clues-query",
-  "version": "2.0.6",
+  "version": "2.0.7",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/test/stats-test.js
+++ b/test/stats-test.js
@@ -68,13 +68,13 @@ t.test('median',{autoend:true},function(t) {
 t.test('null values', async t => {
   t.test('no values', async t => {
     const { sum, cumul, count, min, max, avg, median } = await clues(data,'select.nValue.stats');
-    t.same(sum, undefined, 'non-existant field has undefined sum');
+    t.same(sum, null, 'non-existant field has null sum');
     t.same(cumul, [], 'non-existant field does not add to cumul');
     t.same(count, 0, 'non-existant field shows as zero count');
-    t.same(min, undefined, 'non-existant field has no min');
-    t.same(max, undefined, 'non-existant field has no max');
-    t.same(avg, undefined, 'non-existant field has no avg');
-    t.same(median, undefined, 'non-existant field has no median');
+    t.same(min, null, 'non-existant field has no min');
+    t.same(max, null, 'non-existant field has no max');
+    t.same(avg, null, 'non-existant field has no avg');
+    t.same(median, null, 'non-existant field has no median');
   });
   t.test('mixed null and values', async t => {
     const { sum, cumul, count, min, max, avg, median } = await clues(data,'select.sValue.stats');

--- a/test/stats-test.js
+++ b/test/stats-test.js
@@ -1,9 +1,11 @@
-var clues = require('clues'),
-    Query = require('../index'),
-    
-    data = require('./data');
+const clues = require('clues');
+const Query = require('../index');
+
+let data = require('./data');
 
 data = Object.create(data);
+data.push({'Country': 'Switzerland', 'Aspect': 'Freedom', 'sValue': 17 });
+data.push({'Country': 'Greenland', 'Aspect': 'Health', 'sValue': 6 })
 
 module.exports = t => {
 
@@ -16,7 +18,7 @@ t.test('stats',{autoend:true},function(t) {
         t.same(d.cumul[d.cumul.length-1],2503);
         t.same(d.min,41);
         t.same(d.max,100);
-        t.same(d.count,31);
+        t.same(d.count,30);
       });
   });
   t.test('works on group data',{autoend:true},function(t) {
@@ -60,6 +62,29 @@ t.test('median',{autoend:true},function(t) {
       .then(function(d) {
         t.same(d,12.5);
       });
+  });
+});
+
+t.test('null values', async t => {
+  t.test('no values', async t => {
+    const { sum, cumul, count, min, max, avg, median } = await clues(data,'select.nValue.stats');
+    t.same(sum, undefined, 'non-existant field has undefined sum');
+    t.same(cumul, [], 'non-existant field does not add to cumul');
+    t.same(count, 0, 'non-existant field shows as zero count');
+    t.same(min, undefined, 'non-existant field has no min');
+    t.same(max, undefined, 'non-existant field has no max');
+    t.same(avg, undefined, 'non-existant field has no avg');
+    t.same(median, undefined, 'non-existant field has no median');
+  });
+  t.test('mixed null and values', async t => {
+    const { sum, cumul, count, min, max, avg, median } = await clues(data,'select.sValue.stats');
+    t.same(sum, 23, 'mixed field sum');
+    t.same(cumul, [17, 23], 'mixed field cumul');
+    t.same(count, 2, 'mixed field count');
+    t.same(min, 6, 'mixed field min');
+    t.same(max, 17, 'mixed field max');
+    t.same(avg, 11.5, 'mixed field avg');
+    t.same(median, 11.5, 'mixed field median');
   });
 });
 


### PR DESCRIPTION
Issue: including stats for null or undefined values can lead to misleading aggregations.  (https://github.com/phoenixabs/flashlight/issues/12421)

For stats like sum, min, max, avg, etc. on records that have no numeric values, we now return null instead of 0 or Infinity or -Infinity, etc.

Old: https://master.dev.thenumber.com/#/explorer?key=4470&org=Testing%20Automated%20Report%20Gen&portfolio=master%20mru&filter=%7B%22f%22:%5B%5D,%22v2%22:true%7D&code=person.%0A%20%20borrower.%0A%20%20%20%20credit.%0A%20%20%20%20%20%20tu.%0A%20%20%20%20%20%20%20%20allReports.%0A%20%20%20%20%20%20%20%20%20%200.%0A%20%20%20%20%20%20%20%20%20%20%20%20trade.%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20pick.%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20portfolioType%3Dinstallment.%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20where.%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20and(%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20(accountTypeEnum)%3Dunsecured,%20%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20((dateOpened)%3E$%7Bglobal_app.%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20data.%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20actfunddt%7D)).%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20select.%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20highCredit.%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20stats.%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20sum&preset=b1441e27adf29860c8001a4da4be4a372eaa82e5&state=%7B%0A%20%20key:%20%224470%22,%0A%20%20org:%20%22Testing%20Automated%20Report%20Gen%22,%0A%20%20portfolio:%20%22master%20mru%22,%0A%20%20filter:%20%22%7B%5C%22f%5C%22:%5B%5D,%5C%22v2%5C%22:true%7D%22,%0A%20%20preset:%20%22b1441e27adf29860c8001a4da4be4a372eaa82e5%22,%0A%20%20state:%20%223236b72fcfdf%22%0A%7D

New: https://12421-null-stats.dev.thenumber.com/#/explorer?key=4470&org=Testing%20Automated%20Report%20Gen&portfolio=master%20mru&filter=%7B%22f%22:%5B%5D,%22v2%22:true%7D&code=person.%0A%20%20borrower.%0A%20%20%20%20credit.%0A%20%20%20%20%20%20tu.%0A%20%20%20%20%20%20%20%20allReports.%0A%20%20%20%20%20%20%20%20%20%200.%0A%20%20%20%20%20%20%20%20%20%20%20%20trade.%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20pick.%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20portfolioType%3Dinstallment.%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20where.%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20and(%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20(accountTypeEnum)%3Dunsecured,%20%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20((dateOpened)%3E$%7Bglobal_app.%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20data.%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20actfunddt%7D)).%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20select.%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20highCredit.%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20stats.%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20sum&preset=b1441e27adf29860c8001a4da4be4a372eaa82e5&state=%7B%0A%20%20key:%20%224470%22,%0A%20%20org:%20%22Testing%20Automated%20Report%20Gen%22,%0A%20%20portfolio:%20%22master%20mru%22,%0A%20%20filter:%20%22%7B%5C%22f%5C%22:%5B%5D,%5C%22v2%5C%22:true%7D%22,%0A%20%20preset:%20%22b1441e27adf29860c8001a4da4be4a372eaa82e5%22,%0A%20%20state:%20%223236b72fcfdf%22%0A%7D